### PR TITLE
Add location coords to InitConversation

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -76,6 +76,16 @@ function initBotConversation() {
     if (tokenPayload.directLineURI) {
         domain =  "https://" +  tokenPayload.directLineURI + "/v3/directline";
     }
+    let location = undefined;
+    if (tokenPayload.location) {
+        location = tokenPayload.location;
+    } else {
+        // set default location if desired
+        /*location = {
+            lat: 44.86448450671394,
+            long: -93.32597021107624
+        }*/
+    }
     var botConnection = window.WebChat.createDirectLine({
         token: tokenPayload.connectorToken,
         domain: domain
@@ -109,6 +119,7 @@ function initBotConversation() {
                             triggeredScenario: {
                                 trigger: "{scenario_id}",
                                 args: {
+                                    location: location,
                                     myVar1: "{custom_arg_1}",
                                     myVar2: "{custom_arg_2}"
                                 }


### PR DESCRIPTION
Adds location object to InitConversation args

Example usage in scenario manager:
`'Lat: ' + scenario.scenarioArgs.location.lat + ' Long: ' + scenario.scenarioArgs.location.long`